### PR TITLE
Specify tags in decorator

### DIFF
--- a/aiohttp_apischema/generator.py
+++ b/aiohttp_apischema/generator.py
@@ -84,6 +84,7 @@ class _OperationObject(TypedDict, total=False):
     requestBody: _RequestBodyObject
     responses: dict[str, _ResponseObject]
     summary: str
+    tags: List[str]
 
 class _PathObject(TypedDict, total=False):
     delete: _OperationObject
@@ -143,7 +144,7 @@ class SchemaGenerator:
             info = {"title": "API", "version": "1.0"}
         self._openapi: _OpenApi = {"openapi": "3.1.0", "info": info}
 
-    def _save_handler(self, handler: APIHandler[APIResponse[object, int]]) -> _EndpointData:
+    def _save_handler(self, handler: APIHandler[APIResponse[object, int]], tags=[]) -> _EndpointData:
         ep_data: _EndpointData = {}
         docs = inspect.getdoc(handler)
         if docs:
@@ -154,6 +155,8 @@ class SchemaGenerator:
                 ep_data["summary"] = summary
             if desc:
                 ep_data["desc"] = desc
+            if tags:
+                ep_data["tags"] = tags
 
         sig = inspect.signature(handler, eval_str=True)
         params = iter(sig.parameters.values())
@@ -210,9 +213,9 @@ class SchemaGenerator:
 
         return decorator
 
-    def api(self) -> Callable[[APIHandler[_Resp]], Callable[[web.Request], Awaitable[_Resp]]]:
+    def api(self, tags=[]) -> Callable[[APIHandler[_Resp]], Callable[[web.Request], Awaitable[_Resp]]]:
         def decorator(handler: APIHandler[_Resp]) -> Callable[[web.Request], Awaitable[_Resp]]:
-            ep_data = self._save_handler(handler)
+            ep_data = self._save_handler(handler, tags=tags)
             ta = ep_data.get("body")
             if ta:
                 @functools.wraps(handler)
@@ -265,10 +268,15 @@ class SchemaGenerator:
                 operation: _OperationObject = {"operationId": route.handler.__name__}
                 summary = endpoints.get("summary")
                 desc = endpoints.get("desc")
+                tags = endpoints.get("tags")
+
                 if summary:
                     operation["summary"] = summary
                 if desc:
                     operation["description"] = desc
+                if tags:
+                    operation["tags"] = tags
+
                 path_data[method] = operation
 
                 body = endpoints.get("body")

--- a/aiohttp_apischema/generator.py
+++ b/aiohttp_apischema/generator.py
@@ -84,7 +84,7 @@ class _OperationObject(TypedDict, total=False):
     requestBody: _RequestBodyObject
     responses: dict[str, _ResponseObject]
     summary: str
-    tags: List[str]
+    tags: list[str]
 
 class _PathObject(TypedDict, total=False):
     delete: _OperationObject

--- a/aiohttp_apischema/generator.py
+++ b/aiohttp_apischema/generator.py
@@ -144,7 +144,7 @@ class SchemaGenerator:
             info = {"title": "API", "version": "1.0"}
         self._openapi: _OpenApi = {"openapi": "3.1.0", "info": info}
 
-    def _save_handler(self, handler: APIHandler[APIResponse[object, int]], tags=[]) -> _EndpointData:
+    def _save_handler(self, handler: APIHandler[APIResponse[object, int]], tags: Iterable[str] = ()) -> _EndpointData:
         ep_data: _EndpointData = {}
         docs = inspect.getdoc(handler)
         if docs:
@@ -156,7 +156,7 @@ class SchemaGenerator:
             if desc:
                 ep_data["desc"] = desc
             if tags:
-                ep_data["tags"] = tags
+                ep_data["tags"] = list(tags)
 
         sig = inspect.signature(handler, eval_str=True)
         params = iter(sig.parameters.values())
@@ -213,7 +213,7 @@ class SchemaGenerator:
 
         return decorator
 
-    def api(self, tags=[]) -> Callable[[APIHandler[_Resp]], Callable[[web.Request], Awaitable[_Resp]]]:
+    def api(self, tags: Iterable[str] = ()) -> Callable[[APIHandler[_Resp]], Callable[[web.Request], Awaitable[_Resp]]]:
         def decorator(handler: APIHandler[_Resp]) -> Callable[[web.Request], Awaitable[_Resp]]:
             ep_data = self._save_handler(handler, tags=tags)
             ta = ep_data.get("body")

--- a/aiohttp_apischema/generator.py
+++ b/aiohttp_apischema/generator.py
@@ -5,7 +5,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from http import HTTPStatus
 from pathlib import Path
 from types import UnionType
-from typing import Any, Collection, Literal, TypedDict, TypeGuard, TypeVar, cast, get_args, get_origin
+from typing import Any, Iterable, Literal, TypedDict, TypeGuard, TypeVar, cast, get_args, get_origin
 
 from aiohttp import web
 from aiohttp.hdrs import METH_ALL
@@ -157,7 +157,7 @@ class SchemaGenerator:
             if desc:
                 ep_data["desc"] = desc
             if tags:
-                ep_data["tags"] = list(tags)
+                ep_data["tags"] = tags
 
         sig = inspect.signature(handler, eval_str=True)
         params = iter(sig.parameters.values())
@@ -188,7 +188,7 @@ class SchemaGenerator:
 
         return ep_data
 
-    def api_view(self, tags: Collection[str] = ()) -> Callable[[type[_View]], type[_View]]:
+    def api_view(self, tags: Iterable[str] = ()) -> Callable[[type[_View]], type[_View]]:
         def decorator(view: type[_View]) -> type[_View]:
             self._endpoints[view] = {"meths": {}}
 
@@ -214,7 +214,7 @@ class SchemaGenerator:
 
         return decorator
 
-    def api(self, tags: Collection[str] = ()) -> Callable[[APIHandler[_Resp]], Callable[[web.Request], Awaitable[_Resp]]]:
+    def api(self, tags: Iterable[str] = ()) -> Callable[[APIHandler[_Resp]], Callable[[web.Request], Awaitable[_Resp]]]:
         def decorator(handler: APIHandler[_Resp]) -> Callable[[web.Request], Awaitable[_Resp]]:
             ep_data = self._save_handler(handler, tags=list(tags))
             ta = ep_data.get("body")

--- a/aiohttp_apischema/generator.py
+++ b/aiohttp_apischema/generator.py
@@ -5,7 +5,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from http import HTTPStatus
 from pathlib import Path
 from types import UnionType
-from typing import Any, Literal, TypedDict, TypeGuard, TypeVar, cast, get_args, get_origin
+from typing import Any, Iterable, Literal, TypedDict, TypeGuard, TypeVar, cast, get_args, get_origin
 
 from aiohttp import web
 from aiohttp.hdrs import METH_ALL

--- a/aiohttp_apischema/generator.py
+++ b/aiohttp_apischema/generator.py
@@ -5,7 +5,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from http import HTTPStatus
 from pathlib import Path
 from types import UnionType
-from typing import Any, Iterable, Literal, TypedDict, TypeGuard, TypeVar, cast, get_args, get_origin
+from typing import Any, Collection, Literal, TypedDict, TypeGuard, TypeVar, cast, get_args, get_origin
 
 from aiohttp import web
 from aiohttp.hdrs import METH_ALL
@@ -59,6 +59,7 @@ class _EndpointData(TypedDict, total=False):
     desc: str
     resps: dict[int, TypeAdapter[Any]]
     summary: str
+    tags: list[str]
 
 class _Endpoint(TypedDict, total=False):
     desc: str
@@ -144,7 +145,7 @@ class SchemaGenerator:
             info = {"title": "API", "version": "1.0"}
         self._openapi: _OpenApi = {"openapi": "3.1.0", "info": info}
 
-    def _save_handler(self, handler: APIHandler[APIResponse[object, int]], tags: Iterable[str] = ()) -> _EndpointData:
+    def _save_handler(self, handler: APIHandler[APIResponse[object, int]], tags: Collection[str] = ()) -> _EndpointData:
         ep_data: _EndpointData = {}
         docs = inspect.getdoc(handler)
         if docs:
@@ -213,7 +214,7 @@ class SchemaGenerator:
 
         return decorator
 
-    def api(self, tags: Iterable[str] = ()) -> Callable[[APIHandler[_Resp]], Callable[[web.Request], Awaitable[_Resp]]]:
+    def api(self, tags: Collection[str] = ()) -> Callable[[APIHandler[_Resp]], Callable[[web.Request], Awaitable[_Resp]]]:
         def decorator(handler: APIHandler[_Resp]) -> Callable[[web.Request], Awaitable[_Resp]]:
             ep_data = self._save_handler(handler, tags=tags)
             ta = ep_data.get("body")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -252,9 +252,9 @@ async def test_view(aiohttp_client: AiohttpClient) -> None:
 async def test_tags(aiohttp_client: AiohttpClient) -> None:
     schema_gen = SchemaGenerator()
 
-    _tags = ["a_tag"]
+    tags = ("a_tag", "b_tag")
 
-    @schema_gen.api(tags=_tags)
+    @schema_gen.api(tags=tags)
     async def get_number(
         request: web.Request,
     ) -> APIResponse[tuple[Poll, ...], Literal[200]]:
@@ -270,4 +270,4 @@ async def test_tags(aiohttp_client: AiohttpClient) -> None:
         assert resp.ok
         schema = await resp.json()
 
-    assert schema["paths"]["/number"]["get"]["tags"] == _tags
+    assert schema["paths"]["/number"]["get"]["tags"] == ["a_tag", "b_tag"]


### PR DESCRIPTION
## What do these changes do?

Allow to specify tags in the decorator:

```
@SCHEMA.api(tags=["UseCase"])
```

## Are there changes in behavior for the user?

If tags is not specified the behavior is the same, when it is the paths will be [grouped](https://swagger.io/docs/specification/v3_0/grouping-operations-with-tags/)

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes

If there's interest I don't mind adding tests add documentation